### PR TITLE
initialise PROXY variable to avoid instance where no PROXY env exists…

### DIFF
--- a/build-setup.sh
+++ b/build-setup.sh
@@ -15,6 +15,7 @@ target=${target:-qemu}
 distro=${distro:-ubuntu}
 WORKSPACE=${WORKSPACE:-${HOME}/${RANDOM}${RANDOM}}
 http_proxy=${http_proxy:-}
+PROXY=""
 
 # Timestamp for job
 echo "Build started, $(date)"


### PR DESCRIPTION
… and set -e catches ubound variable

This should stop the build script from exiting when no proxy environment variables are set.

@shenki 