### PR TITLE
fix: disable Dockerfile always check for package updates

### DIFF
--- a/build-setup.sh
+++ b/build-setup.sh
@@ -48,10 +48,28 @@ FROM fedora:latest
 
 ${PROXY}
 
-# change datestamp below to force a cache refresh
-RUN echo 201603091439 && dnf --refresh upgrade -y
-RUN dnf install -y git subversion gcc gcc-c++ make perl-Thread-Queue perl-Data-Dumper diffstat texinfo \
-chrpath wget SDL-devel patch bzip2 tar cpio findutils socat which python-devel perl-bignum
+RUN dnf --refresh upgrade -y && dnf install -y \
+	bzip2 \
+	chrpath \
+	cpio \
+	diffstat \
+	findutils \
+	gcc \
+	gcc-c++ \
+	git \
+	make \
+	patch \
+	perl-bignum \
+	perl-Data-Dumper \
+	perl-Thread-Queue \
+	python-devel \
+	SDL-devel \
+	socat \
+	subversion \
+	tar \
+	texinfo \
+	wget \
+	which
 
 RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
 RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
@@ -72,15 +90,25 @@ FROM ubuntu:latest
 
 ${PROXY}
 
-# update datestamp below to force a cache refresh
-RUN echo 201603091439 && apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git subversion diffstat texinfo \
-  chrpath wget libthread-queue-any-perl libdata-dumper-simple-perl python libsdl1.2-dev gawk socat debianutils
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+	build-essential \
+	chrpath \
+	debianutils \
+	diffstat \
+	gawk \
+	git \
+	libdata-dumper-simple-perl \
+	libsdl1.2-dev \
+	libthread-queue-any-perl \
+	python \
+	socat \
+	subversion \
+	texinfo \
+	wget
 
 RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
 RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
-
 
 USER ${USER}
 ENV HOME ${HOME}

--- a/build-setup.sh
+++ b/build-setup.sh
@@ -48,7 +48,8 @@ FROM fedora:latest
 
 ${PROXY}
 
-RUN dnf --refresh upgrade -y
+# change datestamp below to force a cache refresh
+RUN echo 201603091439 && dnf --refresh upgrade -y
 RUN dnf install -y git subversion gcc gcc-c++ make perl-Thread-Queue perl-Data-Dumper diffstat texinfo \
 chrpath wget SDL-devel patch bzip2 tar cpio findutils socat which python-devel perl-bignum
 
@@ -71,8 +72,8 @@ FROM ubuntu:latest
 
 ${PROXY}
 
-#RUN echo $(date +%s) && apt-get update
-RUN apt-get update
+# update datestamp below to force a cache refresh
+RUN echo 201603091439 && apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git subversion diffstat texinfo \
   chrpath wget libthread-queue-any-perl libdata-dumper-simple-perl python libsdl1.2-dev gawk socat debianutils

--- a/build-setup.sh
+++ b/build-setup.sh
@@ -48,7 +48,7 @@ FROM fedora:latest
 
 ${PROXY}
 
-RUN dnf --refresh upgrade -y && dnf install -y \
+RUN dnf --refresh install -y \
 	bzip2 \
 	chrpath \
 	cpio \
@@ -91,7 +91,7 @@ FROM ubuntu:latest
 ${PROXY}
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+RUN apt-get update && apt-get install -yy \
 	build-essential \
 	chrpath \
 	debianutils \

--- a/initramfs-build.sh
+++ b/initramfs-build.sh
@@ -24,7 +24,7 @@ FROM ubuntu:15.10
 ${PROXY}
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+RUN apt-get update && apt-get install -yy \
 	bc \
 	build-essential \
 	cpio \

--- a/initramfs-build.sh
+++ b/initramfs-build.sh
@@ -23,11 +23,19 @@ FROM ubuntu:15.10
 
 ${PROXY}
 
-# update datestamp below to force a cache refresh
-RUN echo 201603091439 && apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy bc build-essential cpio git python unzip wget
-RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+	bc \
+	build-essential \
+	cpio \
+	git \
+	python \
+	unzip \
+	wget
+
+RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
+RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+
 RUN locale-gen en_AU.utf8
 
 USER ${USER}

--- a/initramfs-build.sh
+++ b/initramfs-build.sh
@@ -23,8 +23,8 @@ FROM ubuntu:15.10
 
 ${PROXY}
 
-#RUN echo $(date +%s) && apt-get update
-RUN apt-get update
+# update datestamp below to force a cache refresh
+RUN echo 201603091439 && apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy bc build-essential cpio git python unzip wget
 RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}

--- a/kernel-build-setup.sh
+++ b/kernel-build-setup.sh
@@ -29,7 +29,7 @@ FROM fedora:latest
 
 ${PROXY}
 
-RUN dnf --refresh upgrade -y && dnf install -y \
+RUN dnf --refresh install -y \
 	bc \
 	findutils \
 	git \
@@ -59,7 +59,7 @@ FROM ubuntu:latest
 ${PROXY}
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+RUN apt-get update && apt-get install -yy \
 	bc \
 	build-essential \
 	git \

--- a/kernel-build-setup.sh
+++ b/kernel-build-setup.sh
@@ -29,7 +29,8 @@ FROM fedora:latest
 
 ${PROXY}
 
-RUN dnf --refresh upgrade -y
+# update datestamp below to force a cache refresh
+RUN echo 201603091439 && dnf --refresh upgrade -y
 RUN dnf install -y bc findutils git gcc gcc-arm-linux-gnu hostname make uboot-tools xz
 RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
 
@@ -49,7 +50,8 @@ FROM ubuntu:latest
 
 ${PROXY}
 
-RUN apt-get update
+# update datestamp below to force a cache refresh
+RUN echo 201603091439 && apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy bc build-essential git gcc-arm-none-eabi u-boot-tools
 RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}

--- a/kernel-build-setup.sh
+++ b/kernel-build-setup.sh
@@ -29,10 +29,18 @@ FROM fedora:latest
 
 ${PROXY}
 
-# update datestamp below to force a cache refresh
-RUN echo 201603091439 && dnf --refresh upgrade -y
-RUN dnf install -y bc findutils git gcc gcc-arm-linux-gnu hostname make uboot-tools xz
-RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+RUN dnf --refresh upgrade -y && dnf install -y \
+	bc \
+	findutils \
+	git \
+	gcc \
+	gcc-arm-linux-gnu \
+	hostname \
+	make \
+	uboot-tools xz
+
+RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
+RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
 
 USER ${USER}
 ENV HOME ${HOME}
@@ -50,11 +58,16 @@ FROM ubuntu:latest
 
 ${PROXY}
 
-# update datestamp below to force a cache refresh
-RUN echo 201603091439 && apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy bc build-essential git gcc-arm-none-eabi u-boot-tools
-RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+	bc \
+	build-essential \
+	git \
+	gcc-arm-none-eabi \
+	u-boot-tools
+
+RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
+RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
 
 USER ${USER}
 ENV HOME ${HOME}

--- a/kernel-build.sh
+++ b/kernel-build.sh
@@ -23,8 +23,8 @@ FROM ubuntu:15.10
 
 ${PROXY}
 
-# If we need to fetch new apt repo data, update the timestamp
-RUN echo 201603031716 && apt-get update
+# update datestamp below to force a cache refresh
+RUN echo 201603091439 && apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy bc build-essential git gcc-powerpc64le-linux-gnu
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy software-properties-common

--- a/kernel-build.sh
+++ b/kernel-build.sh
@@ -23,17 +23,20 @@ FROM ubuntu:15.10
 
 ${PROXY}
 
-# update datestamp below to force a cache refresh
-RUN echo 201603091439 && apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy bc build-essential git gcc-powerpc64le-linux-gnu
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy software-properties-common
-RUN apt-add-repository -y multiverse
-# If we need to fetch new apt repo data, update the timestamp
-RUN echo 201603031716 && apt-get update
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yy dwarves sparse
-RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+ENV DEBIAN_FRONTEND noninteractive 
+RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+	bc \
+	build-essential \
+	git \
+	gcc-powerpc64le-linux-gnu \
+	software-properties-common
+
+RUN apt-add-repository -y multiverse && apt-get update && apt-get install -yy \
+	dwarves \
+	sparse
+
+RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
+RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
 
 USER ${USER}
 ENV HOME ${HOME}

--- a/kernel-build.sh
+++ b/kernel-build.sh
@@ -24,7 +24,7 @@ FROM ubuntu:15.10
 ${PROXY}
 
 ENV DEBIAN_FRONTEND noninteractive 
-RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+RUN apt-get update && apt-get install -yy \
 	bc \
 	build-essential \
 	git \

--- a/openpower-build-setup.sh
+++ b/openpower-build-setup.sh
@@ -42,8 +42,9 @@ elif [[ "${distro}" == ubuntu ]]; then
 FROM ubuntu:15.10
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN echo $(date +%s) && apt-get update && \
-	apt-get install -y \
+# update datestamp below to force a cache refresh
+RUN echo 201603091439 && apt-get update
+RUN apt-get install -y \
 	cscope ctags libz-dev libexpat-dev python language-pack-en texinfo \
 	build-essential g++ git bison flex unzip libxml-simple-perl \
 	libxml-sax-perl libxml2-dev libxml2-utils xsltproc wget cpio bc \

--- a/openpower-build-setup.sh
+++ b/openpower-build-setup.sh
@@ -25,10 +25,21 @@ if [[ "${distro}" == fedora ]];then
   Dockerfile=$(cat << EOF
 FROM fedora:latest
 
-RUN dnf --refresh upgrade -y && \
-	dnf install -y vim gcc-c++ flex bison git ctags cscope expat-devel \
-	patch zlib-devel zlib-static perl
-RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+RUN dnf --refresh upgrade -y && dnf install -y \
+	vim \
+	gcc-c++ \
+	flex \
+	bison \
+	git \
+	ctags \
+  	cscope \
+	expat-devel \
+	patch \
+	zlib-devel \
+	zlib-static perl
+
+RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
+RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
 
 USER ${USER}
 ENV HOME ${HOME}
@@ -42,14 +53,32 @@ elif [[ "${distro}" == ubuntu ]]; then
 FROM ubuntu:15.10
 
 ENV DEBIAN_FRONTEND noninteractive
-# update datestamp below to force a cache refresh
-RUN echo 201603091439 && apt-get update
-RUN apt-get install -y \
-	cscope ctags libz-dev libexpat-dev python language-pack-en texinfo \
-	build-essential g++ git bison flex unzip libxml-simple-perl \
-	libxml-sax-perl libxml2-dev libxml2-utils xsltproc wget cpio bc \
-	vim-common
-RUN groupadd -g ${GROUPS} ${USER} && useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
+RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+	bc \
+	bison \
+	build-essential \
+	cscope \
+       	cpio \
+	ctags \
+	flex \
+	g++ \
+	git \
+	libexpat-dev \
+	libz-dev \
+	libxml-sax-perl \
+	libxml-simple-perl \
+	libxml2-dev \
+	libxml2-utils \
+	language-pack-en \
+	python \
+	texinfo \
+	unzip \
+	vim-common \
+	wget\
+	xsltproc
+
+RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
+RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
 
 USER ${USER}
 ENV HOME ${HOME}

--- a/openpower-build-setup.sh
+++ b/openpower-build-setup.sh
@@ -25,18 +25,39 @@ if [[ "${distro}" == fedora ]];then
   Dockerfile=$(cat << EOF
 FROM fedora:latest
 
-RUN dnf --refresh upgrade -y && dnf install -y \
-	vim \
-	gcc-c++ \
-	flex \
+RUN dnf --refresh repolist && dnf install -y \
+	bc \
 	bison \
-	git \
-	ctags \
+	bzip2 \
+	cpio \
   	cscope \
+	ctags \
 	expat-devel \
+	findutils \
+	flex \
+	gcc-c++ \
+	git \
+	libxml2-devel \
+	ncurses-devel \
 	patch \
+	perl \
+	perl-bignum \
+	"perl(Digest::SHA1)" \
+	perl(Env)" \
+	"perl(Fatal)" \
+	"perl(Thread::Queue)" \
+	"perl(XML::SAX)" \
+	"perl(XML::Simple)" \
+	"perl(YAML)" \
+	"perl(XML::LibXML)" \
+	python \
+	tar \
+	unzip \
+	vim \
+	wget \
+	which \
 	zlib-devel \
-	zlib-static perl
+	zlib-static
 
 RUN grep -q ${GROUPS} /etc/group || groupadd -g ${GROUPS} ${USER}
 RUN grep -q ${UID} /etc/passwd || useradd -d ${HOME} -m -u ${UID} -g ${GROUPS} ${USER}
@@ -53,7 +74,7 @@ elif [[ "${distro}" == ubuntu ]]; then
 FROM ubuntu:15.10
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get upgrade -yy && apt-get install -yy \
+RUN apt-get update && apt-get install -yy \
 	bc \
 	bison \
 	build-essential \


### PR DESCRIPTION
set a static datestamp so that apt-get/dnf aren't run each time a new
docker container is built. Increment it if you want to refresh the
package databases in order to install new software or if something
is out of date.

@shenki

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc-build-scripts/7)
<!-- Reviewable:end -->
