### PR TITLE
Add libldap2-dev

### DIFF
--- a/build-unit-test-docker.sh
+++ b/build-unit-test-docker.sh
@@ -146,7 +146,8 @@ RUN apt-get update && apt-get install -yy \
     lcov \
     libpam0g-dev \
     xxd \
-    wget
+    wget \
+    libldap2-dev
 
 RUN pip install inflection
 RUN pip install pycodestyle


### PR DESCRIPTION
phosphor-ldap-config APP uses libldap, So it is required to pull this library into the CI to verify builds.