### PR TITLE
Meson dependencies pattern should pick list items

### DIFF
--- a/scripts/unit-test.py
+++ b/scripts/unit-test.py
@@ -755,7 +755,7 @@ class Meson(BuildSystem):
                 continue
             with open(os.path.join(root, 'meson.build'), 'rt') as f:
                 build_contents = f.read()
-            pattern = r"dependency\('([^']*)'.*?\)\n"
+            pattern = r"dependency\('([^']*)'.*?\),?\n"
             for match in re.finditer(pattern, build_contents):
                 group = match.group(1)
                 maybe_dep = DEPENDENCIES['PKG_CHECK_MODULES'].get(group)


### PR DESCRIPTION
Please refer to [this issue](https://github.com/openbmc/openbmc-build-scripts/issues/27) for details.